### PR TITLE
fix: 修复ollama和lm studio的配置缺失api地址填写 (#40)

### DIFF
--- a/AIOCR/ai_ocr_config.py
+++ b/AIOCR/ai_ocr_config.py
@@ -282,6 +282,12 @@ globalOptions = {
         "type": "text",
         "toolTip": tr("Ollama本地视觉模型，如：llava:latest"),
     },
+    "ollama_api_base": {
+        "title": tr("Ollama API地址"),
+        "default": "http://localhost:11434/api",
+        "type": "text",
+        "toolTip": tr("Ollama本地视觉模型的API地址"),
+    },
 
     # LM Studio配置（本地）
     "lmstudio_api_key": {
@@ -295,6 +301,12 @@ globalOptions = {
         "default": "llava:latest",
         "type": "text",
         "toolTip": tr("LM Studio本地视觉模型，如：llava:latest"),
+    },
+    "lmstudio_api_base": {
+        "title": tr("LM Studio API地址"),
+        "default": "http://localhost:1234/v1",
+        "type": "text",
+        "toolTip": tr("LM Studio本地视觉模型的API地址"),
     },
 
     # Groq配置


### PR DESCRIPTION
在config.py里面添加ollama_api_base和lmstudio_api_base键及其字典，字典内容格式照搬其它的